### PR TITLE
feat(cli): cli

### DIFF
--- a/.env.zsh
+++ b/.env.zsh
@@ -5,7 +5,6 @@
 # - https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/dotenv
 
 NODE_NO_WARNINGS=1
-NODE_OPTIONS='--experimental-specifier-resolution=node'
 PROJECT_CWD=$(node -e "console.log(path.resolve('.'))")
 TS_NODE_PROJECT=$PROJECT_CWD/tsconfig.tsnode.json
 VITEST_SEGFAULT_RETRY=3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,8 +27,6 @@ updates:
       prefix: build
       include: scope
     ignore:
-      - dependency-name: junk
-      - dependency-name: pretty-bytes
       - dependency-name: typescript
     labels:
       - scope:dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
         env:
           NODE_ENV: test
           NODE_NO_WARNINGS: 1
-          NODE_OPTIONS: --es-module-specifier-resolution=node
           TS_NODE_PROJECT: ./tsconfig.tsnode.json
           VITEST_SEGFAULT_RETRY: 3
       - id: pack
@@ -78,5 +77,4 @@ jobs:
         env:
           NODE_ENV: production
           NODE_NO_WARNINGS: 1
-          NODE_OPTIONS: --es-module-specifier-resolution=node
           TS_NODE_PROJECT: ./tsconfig.tsnode.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![conventional commits](https://img.shields.io/badge/conventional%20commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
-[![module type: cjs+esm](https://img.shields.io/badge/module%20type-cjs%2besm-brightgreen)](https://github.com/voxpelli/badges-cjs-esm)
+[![module type: esm](https://img.shields.io/badge/module%20type-esm-brightgreen)](https://github.com/voxpelli/badges-cjs-esm)
 [![npm](https://img.shields.io/npm/v/@flex-development/mkbuild.svg)](https://npmjs.com/package/@flex-development/mkbuild)
 [![license](https://img.shields.io/github/license/flex-development/mkbuild.svg)](LICENSE.md)
 [![typescript](https://badgen.net/badge/-/typescript?color=2a72bc&icon=typescript&label)](https://typescriptlang.org)

--- a/build.config.ts
+++ b/build.config.ts
@@ -11,7 +11,8 @@ import { defineBuildConfig, type Config } from '#src'
  * @const {Config} config
  */
 const config: Config = defineBuildConfig({
-  entries: [{ format: 'esm' }, { ext: '.cjs', format: 'cjs' }]
+  entries: [{ format: 'esm' }],
+  esbuild: { treeShaking: true, tsconfig: 'tsconfig.build.json' }
 })
 
 export default config

--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
     "scripts/postinstall.sh",
     "src"
   ],
-  "bin": {
-    "mkbuild": "./dist/cli.cjs",
-    "mkbuild-esm": "./dist/cli.mjs"
-  },
+  "bin": "./dist/cli.mjs",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -88,7 +85,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "scripts": {
-    "build": "node --loader=./loader.mjs --input-type=module --eval \"(await import('./src/make')).default()\"",
+    "build": "node --loader=./loader.mjs ./src/cli",
     "check:ci": "yarn dedupe --check && yarn check:format && yarn check:lint && yarn check:spelling && yarn check:types && yarn test && NODE_ENV=production yarn pack -o %s-%v.tgz && yarn clean:pack",
     "check:format": "prettier --check .",
     "check:lint": "eslint --exit-on-fatal-error --ext cjs,cts,gql,json,json5,jsonc,md,mjs,mts,ts,yml --max-warnings 0 .",
@@ -128,6 +125,7 @@
     "pkg-types": "0.3.5",
     "postinstall-postinstall": "2.1.0",
     "pretty-bytes": "5.6.0",
+    "sade": "1.8.1",
     "tsconfig-paths": "4.1.0"
   },
   "devDependencies": {
@@ -218,6 +216,7 @@
     "mlly": "patch:mlly@npm%3A0.5.14#patches/mlly+0.5.14.patch"
   },
   "engines": {
+    "node": ">=14",
     "yarn": "4.0.0-rc.14"
   },
   "packageManager": "yarn@4.0.0-rc.14",

--- a/package.json
+++ b/package.json
@@ -35,55 +35,31 @@
   ],
   "bin": "./dist/cli.mjs",
   "exports": {
-    ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
-    },
-    "./config/*": {
-      "import": "./dist/config/*.mjs",
-      "require": "./dist/config/*.cjs"
-    },
-    "./enums": {
-      "import": "./dist/enums/index.mjs",
-      "require": "./dist/enums/index.cjs"
-    },
-    "./enums/*": {
-      "import": "./dist/enums/*.mjs",
-      "require": "./dist/enums/*.cjs"
-    },
-    "./interfaces": {
-      "import": "./dist/interfaces/index.mjs",
-      "require": "./dist/interfaces/index.cjs"
-    },
-    "./interfaces/*": {
-      "import": "./dist/interfaces/*.mjs",
-      "require": "./dist/interfaces/*.cjs"
-    },
+    ".": "./dist/index.mjs",
+    "./config/*": "./dist/config/*.mjs",
+    "./enums": "./dist/enums/index.mjs",
+    "./enums/*": "./dist/enums/*.mjs",
+    "./interfaces": "./dist/interfaces/index.mjs",
+    "./interfaces/*": "./dist/interfaces/*.mjs",
     "./package.json": "./package.json",
-    "./make": {
-      "import": "./dist/make.mjs",
-      "require": "./dist/make.cjs"
-    },
-    "./plugins/*": {
-      "import": "./dist/plugins/*.mjs",
-      "require": "./dist/plugins/*.cjs"
-    },
-    "./types": {
-      "import": "./dist/types/index.mjs",
-      "require": "./dist/types/index.cjs"
-    },
-    "./types/*": {
-      "import": "./dist/types/*.mjs",
-      "require": "./dist/types/*.cjs"
-    },
-    "./utils/*": {
-      "import": "./dist/utils/*.mjs",
-      "require": "./dist/utils/*.cjs"
-    }
+    "./make": "./dist/make.mjs",
+    "./plugins/*": "./dist/plugins/*.mjs",
+    "./types": "./dist/types/index.mjs",
+    "./types/*": "./dist/types/*.mjs",
+    "./utils/*": "./dist/utils/*.mjs"
   },
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*.d.mts",
+        "./dist/*/index.d.mts",
+        "./dist/index.d.mts"
+      ]
+    }
+  },
   "scripts": {
     "build": "node --loader=./loader.mjs ./src/cli",
     "check:ci": "yarn dedupe --check && yarn check:format && yarn check:lint && yarn check:spelling && yarn check:types && yarn test && NODE_ENV=production yarn pack -o %s-%v.tgz && yarn clean:pack",
@@ -124,7 +100,7 @@
     "pathe": "0.3.5",
     "pkg-types": "0.3.5",
     "postinstall-postinstall": "2.1.0",
-    "pretty-bytes": "5.6.0",
+    "pretty-bytes": "6.0.0",
     "sade": "1.8.1",
     "tsconfig-paths": "4.1.0"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+/**
+ * @file CLI
+ * @module mkbuild/cli
+ */
+
+import sade from 'sade'
+import pkg from '../package.json' assert { type: 'json' }
+import make from './make'
+
+sade(pkg.name.replace(/.*\//, ''), true)
+  .version(pkg.version)
+  .describe(pkg.description)
+  .action(async (): Promise<void> => void (await make()))
+  .parse(process.argv)

--- a/src/make.ts
+++ b/src/make.ts
@@ -23,7 +23,6 @@ import write from './utils/write'
  *
  * [1]: https://esbuild.github.io
  *
- * @todo error handling
  * @todo validate build results against package.json
  *
  * @async
@@ -41,75 +40,6 @@ import write from './utils/write'
  * @return {Promise<Result[]>} Build results
  */
 async function make({ cwd, ...config }: Config = {}): Promise<Result[]> {
-  const { globby } = await import('globby')
-  const { isNotJunk } = await import('junk')
-
-  // determine current working directory
-  cwd = pathe.resolve(process.cwd(), cwd ?? '.')
-
-  // build options
-  const {
-    clean,
-    declaration,
-    entries,
-    esbuild,
-    fs,
-    ignore,
-    outdir,
-    pattern
-  }: Required<Config> = defu(await loadBuildConfig(cwd), config, {
-    clean: true,
-    cwd,
-    declaration: true,
-    entries: [],
-    esbuild: {},
-    fs: fse,
-    ignore: IGNORE_PATTERNS,
-    outdir: 'dist',
-    pattern: '**'
-  })
-
-  // normalize build entry options
-  for (const entry of entries) {
-    entry.outdir = entry.outdir ?? outdir
-    entry.source = entry.source ?? 'src'
-
-    entry.format = entry.format ?? 'esm'
-    entry.ext = entry.ext ?? (entry.format === 'esm' ? '.mjs' : '.js')
-
-    entry.declaration =
-      (entry.declaration ?? declaration) && entry.format !== 'iife'
-  }
-
-  /**
-   * `package.json` data.
-   *
-   * @const {PackageJson} pkg
-   */
-  const pkg: PackageJson = await fs.readJson(pathe.resolve(cwd, 'package.json'))
-
-  // print build start info
-  consola.info(color.cyan(`Building ${pkg.name}`))
-
-  // clean output directories
-  if (clean) {
-    /**
-     * Output directory paths.
-     *
-     * @const {string[]} outdirs
-     */
-    const outdirs: string[] = entries.map(entry => {
-      return pathe.resolve(cwd!, entry.outdir!)
-    })
-
-    // remove and recreate output directories
-    for (const outdir of new Set(outdirs)) {
-      await fs.unlink(outdir).catch(() => ({}))
-      await fs.emptyDir(outdir)
-      await fs.mkdirp(outdir)
-    }
-  }
-
   /**
    * Written build results.
    *
@@ -117,93 +47,168 @@ async function make({ cwd, ...config }: Config = {}): Promise<Result[]> {
    */
   const written: [string, Result[]][] = []
 
-  // process build entries
-  for (const entry of entries as Required<Entry>[]) {
-    /**
-     * Build results for {@link entry}.
-     *
-     * @const {Result[]} results
-     */
-    const results: Result[] = []
+  try {
+    const { globby } = await import('globby')
+    const { isNotJunk } = await import('junk')
 
-    /**
-     * Source file paths.
-     *
-     * **Note**: Relative to `entry.source`.
-     *
-     * @const {string[]} sourcefiles
-     */
-    const sourcefiles: string[] = await globby(pattern, {
-      cwd: entry.source,
-      dot: true,
+    // determine current working directory
+    cwd = pathe.resolve(process.cwd(), cwd ?? '.')
+
+    // build options
+    const {
+      clean,
+      declaration,
+      entries,
+      esbuild,
       fs,
-      ignore
+      ignore,
+      outdir,
+      pattern
+    }: Required<Config> = defu(await loadBuildConfig(cwd), config, {
+      clean: true,
+      cwd,
+      declaration: true,
+      entries: [],
+      esbuild: {},
+      fs: fse,
+      ignore: IGNORE_PATTERNS,
+      outdir: 'dist',
+      pattern: '**'
     })
 
-    /**
-     * Source file objects.
-     *
-     * @const {SourceFile[]} sources
-     */
-    const sources: SourceFile[] = sourcefiles.filter(isNotJunk).map(file => {
-      /**
-       * {@link file} resolved.
-       *
-       * @const {string} path
-       */
-      const path: string = pathe.resolve(entry.source, file)
+    // normalize build entry options
+    for (const entry of entries) {
+      entry.outdir = entry.outdir ?? outdir
+      entry.source = entry.source ?? 'src'
 
-      /**
-       * {@link file} extension.
-       *
-       * @var {string} ext
-       */
-      let ext: string = pathe.extname(path)
+      entry.format = entry.format ?? 'esm'
+      entry.ext = entry.ext ?? (entry.format === 'esm' ? '.mjs' : '.js')
 
-      // fix extension if file is a typescript declaration file
-      if (EXT_TS_REGEX.test(ext) && EXT_DTS_REGEX.test(file)) ext = '.d' + ext
-
-      return { ext, file, path }
-    })
-
-    // build sources and write results
-    for (const source of sources) {
-      /**
-       * Build results for {@link source}.
-       *
-       * @const {Result[]} outputs
-       */
-      const outputs: Result[] = await esbuilder(source, entry, {
-        ...esbuild,
-        absWorkingDir: cwd
-      })
-
-      // write build results
-      for (const result of outputs) results.push(await write(result, fs))
+      entry.declaration =
+        (entry.declaration ?? declaration) && entry.format !== 'iife'
     }
 
-    // push written results
-    written.push([pathe.basename(entry.outdir), results])
+    /**
+     * `package.json` data.
+     *
+     * @const {PackageJson} pkg
+     */
+    const pkg: PackageJson = await fs.readJson(
+      pathe.resolve(cwd, 'package.json')
+    )
+
+    // print build start info
+    consola.info(color.cyan(`Building ${pkg.name}`))
+
+    // clean output directories
+    if (clean) {
+      /**
+       * Output directory paths.
+       *
+       * @const {string[]} outdirs
+       */
+      const outdirs: string[] = entries.map(entry => {
+        return pathe.resolve(cwd!, entry.outdir!)
+      })
+
+      // remove and recreate output directories
+      for (const outdir of new Set(outdirs)) {
+        await fs.unlink(outdir).catch(() => ({}))
+        await fs.emptyDir(outdir)
+        await fs.mkdirp(outdir)
+      }
+    }
+
+    // process build entries
+    for (const entry of entries as Required<Entry>[]) {
+      /**
+       * Build results for {@link entry}.
+       *
+       * @const {Result[]} results
+       */
+      const results: Result[] = []
+
+      /**
+       * Source file paths.
+       *
+       * **Note**: Relative to `entry.source`.
+       *
+       * @const {string[]} sourcefiles
+       */
+      const sourcefiles: string[] = await globby(pattern, {
+        cwd: entry.source,
+        dot: true,
+        fs,
+        ignore
+      })
+
+      /**
+       * Source file objects.
+       *
+       * @const {SourceFile[]} sources
+       */
+      const sources: SourceFile[] = sourcefiles.filter(isNotJunk).map(file => {
+        /**
+         * {@link file} resolved.
+         *
+         * @const {string} path
+         */
+        const path: string = pathe.resolve(entry.source, file)
+
+        /**
+         * {@link file} extension.
+         *
+         * @var {string} ext
+         */
+        let ext: string = pathe.extname(path)
+
+        // fix extension if file is a typescript declaration file
+        if (EXT_TS_REGEX.test(ext) && EXT_DTS_REGEX.test(file)) ext = '.d' + ext
+
+        return { ext, file, path }
+      })
+
+      // build sources and write results
+      for (const source of sources) {
+        /**
+         * Build results for {@link source}.
+         *
+         * @const {Result[]} outputs
+         */
+        const outputs: Result[] = await esbuilder(source, entry, {
+          ...esbuild,
+          absWorkingDir: cwd
+        })
+
+        // write build results
+        for (const result of outputs) results.push(await write(result, fs))
+      }
+
+      // push written results
+      written.push([pathe.basename(entry.outdir), results])
+    }
+
+    /**
+     * Total number of bytes in {@link written}.
+     *
+     * @var {number} bytes
+     */
+    let bytes: number = 0
+
+    // print build done info
+    consola.success(color.green(`Build succeeded for ${pkg.name}`))
+
+    // print build analysis
+    for (const [outdir, results] of written) {
+      bytes += results.reduce((acc, result) => acc + result.bytes, 0)
+      consola.log(analyzeResults(outdir, results))
+    }
+
+    // print total build size
+    consola.log('Σ Total build size:', color.cyan(pb(bytes)))
+  } catch (e: unknown) {
+    consola.error(e)
   }
-
-  /**
-   * Total number of bytes in {@link written}.
-   *
-   * @var {number} bytes
-   */
-  let bytes: number = 0
-
-  // print build done info
-  consola.success(color.green(`Build succeeded for ${pkg.name}`))
-
-  // print build analysis
-  for (const [outdir, results] of written) {
-    bytes += results.reduce((acc, result) => acc + result.bytes, 0)
-    consola.log(analyzeResults(outdir, results))
-  }
-
-  // print total build size
-  consola.log('Σ Total build size:', color.cyan(pb(bytes)))
 
   return written.flatMap(([, results]) => results)
 }

--- a/src/make.ts
+++ b/src/make.ts
@@ -8,6 +8,8 @@ import * as color from 'colorette'
 import consola from 'consola'
 import { defu } from 'defu'
 import fse from 'fs-extra'
+import { globby } from 'globby'
+import { isNotJunk } from 'junk'
 import * as pathe from 'pathe'
 import type { PackageJson } from 'pkg-types'
 import pb from 'pretty-bytes'
@@ -48,9 +50,6 @@ async function make({ cwd, ...config }: Config = {}): Promise<Result[]> {
   const written: [string, Result[]][] = []
 
   try {
-    const { globby } = await import('globby')
-    const { isNotJunk } = await import('junk')
-
     // determine current working directory
     cwd = pathe.resolve(process.cwd(), cwd ?? '.')
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": false,
     "jsx": "react-jsxdev",
     "lib": ["dom", "es2021"],
-    "module": "NodeNext",
+    "module": "esnext",
     "moduleResolution": "node",
     "newLine": "lf",
     "noEmit": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -55,6 +55,7 @@ const config = async (): Promise<UserConfig> => {
           '**/__mocks__/**',
           '**/__tests__/**',
           '**/index.ts',
+          'src/cli.ts',
           'src/interfaces',
           'src/plugins/**/options.ts',
           'src/types'

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,6 +915,7 @@ __metadata:
     pretty-format: "npm:29.0.1"
     radash: "npm:7.1.0"
     react: "npm:18.2.0"
+    sade: "npm:1.8.1"
     styled-components: "npm:5.3.5"
     trash-cli: "npm:5.0.0"
     ts-dedent: "npm:2.2.0"
@@ -934,8 +935,7 @@ __metadata:
     typescript:
       optional: true
   bin:
-    mkbuild: ./dist/cli.cjs
-    mkbuild-esm: ./dist/cli.mjs
+    mkbuild: ./dist/cli.mjs
   languageName: unknown
   linkType: soft
 
@@ -6483,6 +6483,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mri@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "mri@npm:1.2.0"
+  checksum: f459cd82edbe77b6296cc59a5005c351cd52f6a6d733539ae91f6dbc61a23c6e558bf9dea2703212b2caf1b0803852f357325612ba848795686577432740bd49
+  languageName: node
+  linkType: hard
+
 "mrmime@npm:^1.0.0":
   version: 1.0.1
   resolution: "mrmime@npm:1.0.1"
@@ -7688,6 +7695,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.1.0"
   checksum: f16db58531d9fdc9e7cce0e33676cf791128db889304247249ba434885d35b1d173eed68ac255fca770da4c0277f97727c5fbbdc659b0b1f04d10fe42ed0dc67
+  languageName: node
+  linkType: hard
+
+"sade@npm:1.8.1":
+  version: 1.8.1
+  resolution: "sade@npm:1.8.1"
+  dependencies:
+    mri: "npm:^1.1.0"
+  checksum: da67f42ec984b58d0eac48d160e4da6d966416bafb88c37556f41f8a52c1ff897ca065984da3d62557ed8622c9999493f133ed6af63e4ea5191342029f37455c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -911,7 +911,7 @@ __metadata:
     postinstall-postinstall: "npm:2.1.0"
     prettier: "npm:2.7.1"
     prettier-plugin-sh: "npm:0.12.8"
-    pretty-bytes: "npm:5.6.0"
+    pretty-bytes: "npm:6.0.0"
     pretty-format: "npm:29.0.1"
     radash: "npm:7.1.0"
     react: "npm:18.2.0"
@@ -7209,10 +7209,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-bytes@npm:5.6.0":
-  version: 5.6.0
-  resolution: "pretty-bytes@npm:5.6.0"
-  checksum: daaf20c7847618fd7935051ffa3b6a6583048d09f0b49a31db66fdb792a77d23f5ae554d10ff1136c9f0bc76c9a4a110647955a16139be3d3ad57072dc9274b6
+"pretty-bytes@npm:6.0.0":
+  version: 6.0.0
+  resolution: "pretty-bytes@npm:6.0.0"
+  checksum: 9033b687324fe83d1a74b2c69637e4eb26693da76010a3446bb24bdec1508106ed930fcfe61a7661a227c32ea2e499b1aa0493fe370c844dfb329e4c7c3ff0ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

### :package: Build

- **esm:** pure esm

### :sparkles: Features

- **cli:** cli

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
RUN  v0.23.1
      Coverage enabled with c8

 ✓ src/__tests__/make.functional.spec.ts > functional:make > error handling > should print build error
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should determine current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should load build config from current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should load package.json from current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build start info
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should clean output directories
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should build source files
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should write build results
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build done info
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build analysis
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print total build size
 ✓ src/config/__tests__/define.spec.ts > unit:config/defineBuildConfig > should return build config object
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cts
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.js
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.json
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mts
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.ts
 ✓ src/config/__tests__/load.spec.ts > unit:config/loadBuildConfig > should return empty object if config is not found
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .cts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .js file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mjs file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .ts file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > messages > should send error if metafile is not enabled
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > messages > should send warning if no source files are found
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.cts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.cts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.mts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.mts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.ts output
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > messages > should send error message if metafile is not enabled
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should do nothing if bundling
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should skip files that are not javascript
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should skip files that are not typescript
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in copied files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in transpiled cjs files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in transpiled esm files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > messages > should send error message if metafile is not enabled
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > messages > should send error message if tsconfig is not found
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should do nothing if bundling
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should skip files that are not javascript
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should skip files that are not typescript
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in copied files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in transpiled cjs files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in transpiled esm files
 ✓ src/utils/__tests__/analyze-results.spec.ts > unit:utils/analyzeResults > should return pretty printed build results
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .cjs file if entry.format is cjs
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.cts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.mts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.ts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .json file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .json5 file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .jsonc file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .mjs file if entry.format is esm
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .cjs file if entry.format is not cjs
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .cts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .js file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .jsx file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .mjs file if entry.format is not esm
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .mts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .ts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .tsx file
 ✓ src/utils/__tests__/esbuilder.spec.ts > unit:utils/esbuilder > should return empty array if source should not be built
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > should return empty array if code is empty string
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return declaration export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return default export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return named export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return star export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return type export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > dynamic > should return dynamic import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return default import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return named import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require.resolve statement array
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should create subdirectories in outdir
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should write build result

Test Files  13 passed (13)
     Tests  78 passed (78)
  Start at  20:46:52
  Duration  51.80s (transform 319ms, setup 3.61s, collect 1.60s, tests 30.94s)

 % Coverage report from c8
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 src                         |     100 |      100 |     100 |     100 |                   
  make.ts                    |     100 |      100 |     100 |     100 |                   
 src/config                  |     100 |      100 |     100 |     100 |                   
  constants.ts               |     100 |      100 |     100 |     100 |                   
  define.ts                  |     100 |      100 |     100 |     100 |                   
  load.ts                    |     100 |      100 |     100 |     100 |                   
  loader-es.ts               |     100 |      100 |     100 |     100 |                   
 src/plugins/dts             |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/fully-specified |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/tsconfig-paths  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/utils                   |     100 |      100 |     100 |     100 |                   
  analyze-results.ts         |     100 |      100 |     100 |     100 |                   
  esbuilder.ts               |     100 |      100 |     100 |     100 |                   
  extract-statements.ts      |     100 |      100 |     100 |     100 |                   
  write.ts                   |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mkbuild                                                                16:50:47
✔ Build succeeded for @flex-development/mkbuild                                                     16:51:03
  dist (total size: 36.9 kB)                                                                        16:51:03
  └─ dist/cli.mjs (278 B)
  └─ dist/cli.d.mts (75 B)
  └─ dist/index.mjs (288 B)
  └─ dist/index.d.mts (302 B)
  └─ dist/make.mjs (3.14 kB)
  └─ dist/make.d.mts (744 B)
  └─ dist/config/constants.mjs (878 B)
  └─ dist/config/constants.d.mts (1.4 kB)
  └─ dist/config/define.mjs (131 B)
  └─ dist/config/define.d.mts (338 B)
  └─ dist/config/load.mjs (633 B)
  └─ dist/config/load.d.mts (627 B)
  └─ dist/config/loader-es.mjs (902 B)
  └─ dist/config/loader-es.d.mts (600 B)
  └─ dist/interfaces/config.mjs (0 B)
  └─ dist/interfaces/config.d.mts (2.24 kB)
  └─ dist/interfaces/entry.mjs (0 B)
  └─ dist/interfaces/entry.d.mts (679 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (340 B)
  └─ dist/interfaces/result.mjs (0 B)
  └─ dist/interfaces/result.d.mts (1.23 kB)
  └─ dist/interfaces/source-file.mjs (0 B)
  └─ dist/interfaces/source-file.d.mts (441 B)
  └─ dist/interfaces/statement.mjs (0 B)
  └─ dist/interfaces/statement.d.mts (686 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (141 B)
  └─ dist/types/output-metadata.mjs (0 B)
  └─ dist/types/output-metadata.d.mts (267 B)
  └─ dist/utils/analyze-results.mjs (575 B)
  └─ dist/utils/analyze-results.d.mts (626 B)
  └─ dist/utils/esbuilder.mjs (2.89 kB)
  └─ dist/utils/esbuilder.d.mts (763 B)
  └─ dist/utils/extract-statements.mjs (1.1 kB)
  └─ dist/utils/extract-statements.d.mts (704 B)
  └─ dist/utils/write.mjs (289 B)
  └─ dist/utils/write.d.mts (616 B)
  └─ dist/plugins/dts/plugin.mjs (3.13 kB)
  └─ dist/plugins/dts/plugin.d.mts (265 B)
  └─ dist/plugins/fully-specified/plugin.mjs (3.52 kB)
  └─ dist/plugins/fully-specified/plugin.d.mts (1.56 kB)
  └─ dist/plugins/tsconfig-paths/options.mjs (0 B)
  └─ dist/plugins/tsconfig-paths/options.d.mts (1.04 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs (2.94 kB)
  └─ dist/plugins/tsconfig-paths/plugin.d.mts (507 B)
Σ Total build size: 36.9 kB                                                                         16:51:03
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

- resolves #5 

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

- [Pure ESM package][2]

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mkbuild/blob/main/CONTRIBUTING.md#pull-request-titles
[2]: https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
