### PR TITLE
feat(esbuild): source map support

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -12,7 +12,12 @@ import { defineBuildConfig, type Config } from '#src'
  */
 const config: Config = defineBuildConfig({
   entries: [{ format: 'esm' }],
-  esbuild: { treeShaking: true, tsconfig: 'tsconfig.build.json' }
+  esbuild: {
+    sourcemap: 'external',
+    sourcesContent: false,
+    treeShaking: true,
+    tsconfig: 'tsconfig.build.json'
+  }
 })
 
 export default config

--- a/src/plugins/dts/__tests__/plugin.integration.spec.ts
+++ b/src/plugins/dts/__tests__/plugin.integration.spec.ts
@@ -20,7 +20,12 @@ describe('integration:plugins/dts', () => {
 
   beforeEach(() => {
     subject = testSubject()
-    options = { ...ESBUILD_OPTIONS, logLevel: 'silent', plugins: [subject] }
+    options = {
+      ...ESBUILD_OPTIONS,
+      logLevel: 'silent',
+      plugins: [subject],
+      sourcemap: true
+    }
   })
 
   describe('esbuild', () => {
@@ -67,16 +72,16 @@ describe('integration:plugins/dts', () => {
           loader: { '.cts': 'ts' },
           outExtension: { '.js': '.cjs' }
         })
-        outputFiles[1]!.path = path.format({
+        outputFiles[2]!.path = path.format({
           dir: ESBUILD_OPTIONS.outdir,
-          name: path.basename(outputFiles[1]!.path)
+          name: path.basename(outputFiles[2]!.path)
         })
 
         // Expect
         expect(errors).to.be.an('array').of.length(0)
         expect(warnings).to.be.an('array').of.length(0)
-        expect(outputFiles).to.be.an('array').of.length(2)
-        expect(pick(outputFiles[1]!, ['path', 'text'])).toMatchSnapshot()
+        expect(outputFiles).to.be.an('array').of.length(3)
+        expect(pick(outputFiles[2]!, ['path', 'text'])).toMatchSnapshot()
       })
 
       it('should add .d.cts output for copied file', async () => {
@@ -117,16 +122,16 @@ describe('integration:plugins/dts', () => {
           loader: { '.mts': 'ts' },
           outExtension: { '.js': '.mjs' }
         })
-        outputFiles[1]!.path = path.format({
+        outputFiles[2]!.path = path.format({
           dir: ESBUILD_OPTIONS.outdir,
-          name: path.basename(outputFiles[1]!.path)
+          name: path.basename(outputFiles[2]!.path)
         })
 
         // Expect
         expect(errors).to.be.an('array').of.length(0)
         expect(warnings).to.be.an('array').of.length(0)
-        expect(outputFiles).to.be.an('array').of.length(2)
-        expect(pick(outputFiles[1]!, ['path', 'text'])).toMatchSnapshot()
+        expect(outputFiles).to.be.an('array').of.length(3)
+        expect(pick(outputFiles[2]!, ['path', 'text'])).toMatchSnapshot()
       })
 
       it('should add .d.mts output for copied file', async () => {
@@ -166,16 +171,16 @@ describe('integration:plugins/dts', () => {
           format: 'esm',
           loader: { '.ts': 'ts' }
         })
-        outputFiles[1]!.path = path.format({
+        outputFiles[2]!.path = path.format({
           dir: ESBUILD_OPTIONS.outdir,
-          name: path.basename(outputFiles[1]!.path)
+          name: path.basename(outputFiles[2]!.path)
         })
 
         // Expect
         expect(errors).to.be.an('array').of.length(0)
         expect(warnings).to.be.an('array').of.length(0)
-        expect(outputFiles).to.be.an('array').of.length(2)
-        expect(pick(outputFiles[1]!, ['path', 'text'])).toMatchSnapshot()
+        expect(outputFiles).to.be.an('array').of.length(3)
+        expect(pick(outputFiles[2]!, ['path', 'text'])).toMatchSnapshot()
       })
     })
   })

--- a/src/plugins/dts/plugin.ts
+++ b/src/plugins/dts/plugin.ts
@@ -192,6 +192,11 @@ const plugin = (): Plugin => {
          */
         const output_ext: string = pathe.extname(output.path)
 
+        // do nothing if output file isn't javascript or typescript
+        if (!EXT_JS_REGEX.test(output_ext) && !EXT_TS_REGEX.test(output_ext)) {
+          return [output]
+        }
+
         /**
          * Relative path to output file.
          *

--- a/src/utils/esbuilder.ts
+++ b/src/utils/esbuilder.ts
@@ -24,7 +24,6 @@ import * as pathe from 'pathe'
  *
  * @todo support bundling
  * @todo support code splitting
- * @todo support sourcemaps
  *
  * @async
  *
@@ -55,9 +54,6 @@ const esbuilder = async (
   delete options.bundle
   delete options.chunkNames
   delete options.external
-  delete options.sourceRoot
-  delete options.sourcemap
-  delete options.sourcesContent
   delete options.splitting
 
   // normalize options


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

### :sparkles: Features

- source map support

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
RUN  v0.23.1
      Coverage enabled with c8

✓ src/__tests__/make.functional.spec.ts > functional:make > error handling > should print build error
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should determine current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should load build config from current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should load package.json from current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build start info
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should clean output directories
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should build source files
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should write build results
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build done info
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print build analysis
 ✓ src/__tests__/make.functional.spec.ts > functional:make > success > should print total build size
 ✓ src/config/__tests__/define.spec.ts > unit:config/defineBuildConfig > should return build config object
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cts
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.js
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.json
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mts
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.ts
 ✓ src/config/__tests__/load.spec.ts > unit:config/loadBuildConfig > should return empty object if config is not found
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .cts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .js file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mjs file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .ts file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > messages > should send error if metafile is not enabled
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > messages > should send warning if no source files are found
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.cts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.cts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.mts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.mts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > typescript declarations > should add .d.ts output
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > messages > should send error message if metafile is not enabled
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should do nothing if bundling
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should skip files that are not javascript
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > noop > should skip files that are not typescript
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in copied files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in transpiled cjs files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > specifiers > should fill specifiers in transpiled esm files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > messages > should send error message if metafile is not enabled
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > messages > should send error message if tsconfig is not found
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should do nothing if bundling
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should skip files that are not javascript
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > noop > should skip files that are not typescript
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in copied files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in transpiled cjs files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > path aliases > should resolve aliases in transpiled esm files
 ✓ src/utils/__tests__/analyze-results.spec.ts > unit:utils/analyzeResults > should return pretty printed build results
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .cjs file if entry.format is cjs
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.cts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.mts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .d.ts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .json file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .json5 file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .jsonc file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transfer > should transfer .mjs file if entry.format is esm
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .cjs file if entry.format is not cjs
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .cts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .js file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .jsx file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .mjs file if entry.format is not esm
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .mts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .ts file
 ✓ src/utils/__tests__/esbuilder.functional.spec.ts > functional:utils/esbuilder > file-to-file > transpilation > should transpile .tsx file
 ✓ src/utils/__tests__/esbuilder.spec.ts > unit:utils/esbuilder > should return empty array if source should not be built
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > should return empty array if code is empty string
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return declaration export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return default export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return named export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return star export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return type export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > dynamic > should return dynamic import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return default import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return named import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require.resolve statement array
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should create subdirectories in outdir
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should write build result

Test Files  13 passed (13)
     Tests  78 passed (78)
  Start at  01:56:30
  Duration  46.03s (transform 295ms, setup 2.94s, collect 1.40s, tests 27.95s)

 % Coverage report from c8
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 src                         |     100 |      100 |     100 |     100 |                   
  make.ts                    |     100 |      100 |     100 |     100 |                   
 src/config                  |     100 |      100 |     100 |     100 |                   
  constants.ts               |     100 |      100 |     100 |     100 |                   
  define.ts                  |     100 |      100 |     100 |     100 |                   
  load.ts                    |     100 |      100 |     100 |     100 |                   
  loader-es.ts               |     100 |      100 |     100 |     100 |                   
 src/plugins/dts             |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/fully-specified |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/tsconfig-paths  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/utils                   |     100 |      100 |     100 |     100 |                   
  analyze-results.ts         |     100 |      100 |     100 |     100 |                   
  esbuilder.ts               |     100 |      100 |     100 |     100 |                   
  extract-statements.ts      |     100 |      100 |     100 |     100 |                   
  write.ts                   |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mkbuild                                                                22:07:15
✔ Build succeeded for @flex-development/mkbuild                                                     22:07:30
  dist (total size: 52.5 kB)                                                                        22:07:30
  └─ dist/cli.mjs.map (290 B)
  └─ dist/cli.mjs (278 B)
  └─ dist/cli.d.mts (75 B)
  └─ dist/index.mjs.map (177 B)
  └─ dist/index.mjs (288 B)
  └─ dist/index.d.mts (302 B)
  └─ dist/make.mjs.map (2.32 kB)
  └─ dist/make.mjs (3.14 kB)
  └─ dist/make.d.mts (744 B)
  └─ dist/config/constants.mjs.map (487 B)
  └─ dist/config/constants.mjs (878 B)
  └─ dist/config/constants.d.mts (1.4 kB)
  └─ dist/config/define.mjs.map (152 B)
  └─ dist/config/define.mjs (131 B)
  └─ dist/config/define.d.mts (338 B)
  └─ dist/config/load.mjs.map (508 B)
  └─ dist/config/load.mjs (633 B)
  └─ dist/config/load.d.mts (627 B)
  └─ dist/config/loader-es.mjs.map (726 B)
  └─ dist/config/loader-es.mjs (902 B)
  └─ dist/config/loader-es.d.mts (600 B)
  └─ dist/interfaces/config.mjs.map (69 B)
  └─ dist/interfaces/config.mjs (0 B)
  └─ dist/interfaces/config.d.mts (2.24 kB)
  └─ dist/interfaces/entry.mjs.map (69 B)
  └─ dist/interfaces/entry.mjs (0 B)
  └─ dist/interfaces/entry.d.mts (679 B)
  └─ dist/interfaces/index.mjs.map (69 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (340 B)
  └─ dist/interfaces/result.mjs.map (69 B)
  └─ dist/interfaces/result.mjs (0 B)
  └─ dist/interfaces/result.d.mts (1.23 kB)
  └─ dist/interfaces/source-file.mjs.map (69 B)
  └─ dist/interfaces/source-file.mjs (0 B)
  └─ dist/interfaces/source-file.d.mts (441 B)
  └─ dist/interfaces/statement.mjs.map (69 B)
  └─ dist/interfaces/statement.mjs (0 B)
  └─ dist/interfaces/statement.d.mts (686 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (141 B)
  └─ dist/types/output-metadata.mjs.map (69 B)
  └─ dist/types/output-metadata.mjs (0 B)
  └─ dist/types/output-metadata.d.mts (267 B)
  └─ dist/utils/analyze-results.mjs.map (541 B)
  └─ dist/utils/analyze-results.mjs (575 B)
  └─ dist/utils/analyze-results.d.mts (626 B)
  └─ dist/utils/esbuilder.mjs.map (2.01 kB)
  └─ dist/utils/esbuilder.mjs (2.8 kB)
  └─ dist/utils/esbuilder.d.mts (735 B)
  └─ dist/utils/extract-statements.mjs.map (901 B)
  └─ dist/utils/extract-statements.mjs (1.1 kB)
  └─ dist/utils/extract-statements.d.mts (704 B)
  └─ dist/utils/write.mjs.map (282 B)
  └─ dist/utils/write.mjs (289 B)
  └─ dist/utils/write.d.mts (616 B)
  └─ dist/plugins/dts/plugin.mjs.map (2.34 kB)
  └─ dist/plugins/dts/plugin.mjs (3.25 kB)
  └─ dist/plugins/dts/plugin.d.mts (265 B)
  └─ dist/plugins/fully-specified/plugin.mjs.map (2.23 kB)
  └─ dist/plugins/fully-specified/plugin.mjs (3.52 kB)
  └─ dist/plugins/fully-specified/plugin.d.mts (1.56 kB)
  └─ dist/plugins/tsconfig-paths/options.mjs.map (69 B)
  └─ dist/plugins/tsconfig-paths/options.mjs (0 B)
  └─ dist/plugins/tsconfig-paths/options.d.mts (1.04 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs.map (2.05 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs (2.94 kB)
  └─ dist/plugins/tsconfig-paths/plugin.d.mts (507 B)
Σ Total build size: 52.5 kB                                                                         22:07:30
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

- resolves #7 

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mkbuild/blob/main/CONTRIBUTING.md#pull-request-titles
