### PR TITLE
release: 1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+## 1.0.0-alpha.1 (2022-09-29)
+
+
+### :package: Build
+
+* fix `ERR_PACKAGE_IMPORT_NOT_DEFINED` ([c5e7153](https://github.com/flex-development/mkbuild/commit/c5e715305b72bd678edd71564ae3afb83f893fee))
+* remove `main` field ([c408bba](https://github.com/flex-development/mkbuild/commit/c408bbaff206b8fbb2094d11794599342801c8fa))
+* **deps-peer:** require `esbuild>=0.15.0` ([8752a0b](https://github.com/flex-development/mkbuild/commit/8752a0b03352f946a6ee52c095e9cc966b9807b0))
+* **esm:** pure esm ([0705685](https://github.com/flex-development/mkbuild/commit/0705685f33ce75b785a83001827d067119c58d09))
+* **exports:** remove extraneous exports ([7bde131](https://github.com/flex-development/mkbuild/commit/7bde1319e5288fed720d1390b1463d2f44380c51))
+* **node:** make programmatic users apply patches ([811ba99](https://github.com/flex-development/mkbuild/commit/811ba99eaea0f4af4dd0330f602a781cb28b860f))
+
+
+### :robot: Continuous Integration
+
+* add [@dependabot](https://github.com/dependabot) config ([9c58d1c](https://github.com/flex-development/mkbuild/commit/9c58d1ca753406bbba92c729360b9b6e400a6e9a))
+* **deps:** bump actions/github-script from 6.2.0 to 6.3.0 ([#11](https://github.com/flex-development/mkbuild/issues/11)) ([bc89779](https://github.com/flex-development/mkbuild/commit/bc89779332666701448a1083b9759017f299ad3b))
+* **deps:** bump actions/setup-node from 3.4.1 to 3.5.0 ([#12](https://github.com/flex-development/mkbuild/issues/12)) ([cff3812](https://github.com/flex-development/mkbuild/commit/cff38122a9d1521d9364fc7c6770cd762c6748f0))
+* **deps:** bump flex-development/dist-tag-action from 1.1.0 to 1.1.1 ([#13](https://github.com/flex-development/mkbuild/issues/13)) ([28ee8df](https://github.com/flex-development/mkbuild/commit/28ee8df69b00be0adf5f0e46543f14eb96a308af))
+
+
+### :pencil: Documentation
+
+* add `module type` badge ([bd9814f](https://github.com/flex-development/mkbuild/commit/bd9814f3a5366bee74b97870e5349d6b59767c39))
+* features ([2eecc98](https://github.com/flex-development/mkbuild/commit/2eecc98e289835f74fe3214791a0718ff257a9b3))
+* remove "built with" section in `README` ([36af097](https://github.com/flex-development/mkbuild/commit/36af0975ca143e4e9e5f3237d71568ca60094296))
+* remove starter todo list ([4e6959f](https://github.com/flex-development/mkbuild/commit/4e6959f7f8b6f3d4840433e938ca3947db5cd51d))
+* update project description ([cd8ee28](https://github.com/flex-development/mkbuild/commit/cd8ee28635f02e9fd6c94209140b47a1158cf2f1))
+* usage ([ba6861a](https://github.com/flex-development/mkbuild/commit/ba6861ab81f47bd2644ff36097cb695ec87d48cb))
+
+
+### :sparkles: Features
+
+* auto-insert `require` definition when creating esm bundles ([b584192](https://github.com/flex-development/mkbuild/commit/b584192816d48085407487df05203de243631f4d))
+* bundling ([#10](https://github.com/flex-development/mkbuild/issues/10)) ([10f79b5](https://github.com/flex-development/mkbuild/commit/10f79b5bb4a38e88c5d173c7832c402a5971b835))
+* file-to-file transpilation ([#4](https://github.com/flex-development/mkbuild/issues/4)) ([1601d26](https://github.com/flex-development/mkbuild/commit/1601d268bce74abafab6a4b0d0e244b35dd1e808))
+* infer build entry from build config ([5168c94](https://github.com/flex-development/mkbuild/commit/5168c9466e33dc7b4325d1a1c53f14e18892ce25))
+* **cli:** cli ([9c82c3b](https://github.com/flex-development/mkbuild/commit/9c82c3b24887cb596f66e5d924bb86f12b6f3186))
+* **esbuild:** source map support ([#8](https://github.com/flex-development/mkbuild/issues/8)) ([fd58b93](https://github.com/flex-development/mkbuild/commit/fd58b93450f5352c29c511b2af394d794b22227e))
+* **options:** default `dts` based on `typescript` install ([2af6d0e](https://github.com/flex-development/mkbuild/commit/2af6d0e6d77a50c5481d3c1d111841f90f1943a4))
+* **options:** options ([#3](https://github.com/flex-development/mkbuild/issues/3)) ([b12fa72](https://github.com/flex-development/mkbuild/commit/b12fa72123b782757dc365d5af11e2ac816a8c80))
+* **plugins:** [`create-require`] recalculate output file size ([6f62642](https://github.com/flex-development/mkbuild/commit/6f62642a5121c44ff9aa79a6cca3418166ceddc6))
+* **plugins:** `create-require` ([885b805](https://github.com/flex-development/mkbuild/commit/885b805db5eefb42fb8b92a4f1736b14e7a23058))
+
+
+### :bug: Fixes
+
+* **config:** prevent `import.meta.url` from being rewritten ([3e9c7c8](https://github.com/flex-development/mkbuild/commit/3e9c7c881cbc93156fe31176c7a0090e698dfac6))
+* **config:** prevent json imports from being converted into data urls ([63b1261](https://github.com/flex-development/mkbuild/commit/63b126136d2564c71253f1e22eb1317a0ac983c0))
+
+
+### :house_with_garden: Housekeeping
+
+* update `eslint.globals.JSX` logic ([c997476](https://github.com/flex-development/mkbuild/commit/c9974764b81a684adeb1352b71597d223a3cbd71))
+* update eslint extensions ([95963c6](https://github.com/flex-development/mkbuild/commit/95963c6d7bec157f31f2d8adefcf656d450b3a08))
+* **deps-dev:** resolve esbuild to 0.15.9 ([c0acee4](https://github.com/flex-development/mkbuild/commit/c0acee43767f4a977ad80393d2a6f3075dfaa078))
+* **esm:** cleanup ([0e1abd2](https://github.com/flex-development/mkbuild/commit/0e1abd2bc63613cb1c11a8fbebe4767489b626a5))
+* **github:** update text file extensions in `.gitattributes` ([ff6d830](https://github.com/flex-development/mkbuild/commit/ff6d83096305fdaa512d884688a450a5170fb391))
+* **pkg:** check test coverage in `check:ci` script ([799bb8c](https://github.com/flex-development/mkbuild/commit/799bb8c299cc7f4372a97aacc255d23e40de2383))
+* **pkg:** check types build in `check:ci` script ([e357301](https://github.com/flex-development/mkbuild/commit/e35730159a30a1bbae84bfe39625b751b1440ff6))
+* **pkg:** convert `bugs` and `repository` field to strings ([aff2cd7](https://github.com/flex-development/mkbuild/commit/aff2cd70bb5071e94400c3305b786d234c343b1a))
+* **pkg:** update `keywords` ([98fe7c3](https://github.com/flex-development/mkbuild/commit/98fe7c340b50f105d32ad0d402c4c22ff28f7bbd))
+* **tests:** cleanup test environment ([34a0fb0](https://github.com/flex-development/mkbuild/commit/34a0fb0f6b73038734b2ab818df29fd2f8cae841))
+* **tests:** remove `.env.test` ([0132bd3](https://github.com/flex-development/mkbuild/commit/0132bd352191a09bb80414ccfeb41e43b82eb1c0))
+* **ts:** set `module` to `NodeNext` ([2917af4](https://github.com/flex-development/mkbuild/commit/2917af4ea5ae200f46565b3c0cbf6f32cc685577))
+* **vscode:** cleanup settings ([4827c7c](https://github.com/flex-development/mkbuild/commit/4827c7cc70ad601d1bb512292954e9e85436de36))
+
+
+### :zap: Refactors
+
+* **node:** add `dependencies` check to default `Entry#createRequire` logic ([0341d74](https://github.com/flex-development/mkbuild/commit/0341d74841628627cfc83527b341c33ffcd6be3f))
+* **options:** `declaration?` -> `dts?` ([3ddb296](https://github.com/flex-development/mkbuild/commit/3ddb29625b6c1220a84b7f35336758a40d05ae17))
+* **utils:** [`esbuilder`] let esbuild externalize node built-ins ([200d360](https://github.com/flex-development/mkbuild/commit/200d360bda3ca7accd5cf7251d6322adeacb4c50))
+* **utils:** [`esbuilder`] remove `TS_NODE_PROJECT` check for tsconfig-paths plugin ([c863c7e](https://github.com/flex-development/mkbuild/commit/c863c7e1467b799609ac084b197ef9f0a4a03cec))
+* **utils:** [`extractStatements`] follow `unsupported-dynamic-import` rule ([ee2110b](https://github.com/flex-development/mkbuild/commit/ee2110ba7abb7214b30a92eb4b72ad9532b7a377))
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/mkbuild",
   "description": "An esbuild based file-to-file transformer and bundler",
-  "version": "0.0.0",
+  "version": "1.0.0-alpha.1",
   "keywords": [
     "bundle",
     "bundler",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0-alpha.1`
- added `CHANGELOG` entry for `1.0.0-alpha.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.23.1
      Coverage enabled with c8

 ✓ src/config/__tests__/define.spec.ts > unit:config/defineBuildConfig > should return build config object
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should do nothing if bundling
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should throw if metafile is not available
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should insert require function definition
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should skip files without __require shim
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if bundling is not enabled
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if not creating esm bundle
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should throw if metafile is not available
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .cts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .js file
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in cjs output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in copied output files
 ✓ src/config/__tests__/load.spec.ts > unit:config/loadBuildConfig > should return empty object if config is not found
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cts
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mjs file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.js
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.json
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mjs
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in esm output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should skip files that are not javascript or typescript
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should load build config
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should clean output directories
 ✓ src/__tests__/make.spec.ts > unit:make > build > should determine current working directory
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should do nothing if bundling
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should throw if metafile is not available
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write all build results
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mts file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mts
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .ts file
 ✓ src/utils/__tests__/analyze-results.spec.ts > unit:utils/analyzeResults > should return pretty printed build results
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should do nothing if bundling
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should throw if metafile is not available
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.ts
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in cjs output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in copied output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases esm output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should skip files that are not javascript or typescript
 ✓ src/__tests__/make.spec.ts > unit:make > build > should load package.json from current working directory
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should enable bundling
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support asset names
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support code splitting
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should use create-require plugin if esm bundle for node
 ✓ src/utils/__tests__/esbuilder.spec.ts > unit:utils/esbuilder > should return build result array
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build start info
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > should return empty array if code is empty string
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return declaration export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return default export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return named export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return star export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return type export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > dynamic > should return dynamic import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return default import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return named import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require.resolve statement array
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output
 ✓ src/__tests__/make.spec.ts > unit:make > build > should build source files
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm transpilation
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs transpilation
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should create subdirectories in output directory
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should write build result
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should return written build result
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should write build result to file system
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object is tsconfig is not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object if user options are not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return user options
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "error" to ImportsNotUsedAsValues.Error
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "preserve" to ImportsNotUsedAsValues.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "remove" to ImportsNotUsedAsValues.Remove
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "preserve" to JsxEmit.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react" to JsxEmit.React
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsx" to JsxEmit.ReactJSX
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsxdev" to JsxEmit.ReactJSXDev
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-native" to JsxEmit.ReactNative
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > lib > should convert libs into typescript library file names
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "amd" to ModuleKind.AMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "commonjs" to ModuleKind.CommonJS
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2015" to ModuleKind.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2020" to ModuleKind.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2022" to ModuleKind.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "esnext" to ModuleKind.ESNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "node16" to ModuleKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "nodenext" to ModuleKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "none" to ModuleKind.None
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "system" to ModuleKind.System
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "umd" to ModuleKind.UMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "auto" to ModuleDetectionKind.Auto
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "force" to ModuleDetectionKind.Force
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "legacy" to ModuleDetectionKind.Legacy
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "classic" to ModuleResolutionKind.Classic
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node" to ModuleResolutionKind.NodeJs
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node16" to ModuleResolutionKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "nodenext" to ModuleResolutionKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "crlf" to NewLineKind.CarriageReturnLineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "lf" to NewLineKind.LineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es3" to ScriptTarget.ES3
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es5" to ScriptTarget.ES5
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2015" to ScriptTarget.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2016" to ScriptTarget.ES2016
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2017" to ScriptTarget.ES2017
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2018" to ScriptTarget.ES2018
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2019" to ScriptTarget.ES2019
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2020" to ScriptTarget.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2021" to ScriptTarget.ES2021
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2022" to ScriptTarget.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "esnext" to ScriptTarget.ESNext
 ✓ src/__tests__/make.spec.ts > unit:make > build > should write build results
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build done info
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use create-require if requested
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build analysis
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output for copied file
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print total build size
 ✓ src/__tests__/make.spec.ts > unit:make > build > should return build results
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use dts if declarations are enabled
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write dts build results only
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if package.json is not found
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error building source file
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error writing build result
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use fully-specified if specifers require extensions
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use tsconfig-paths if tsconfig is detected
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > transpiling > should disable bundling
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.ts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should skip files that are not javascript or typescript

Test Files  22 passed (22)
     Tests  128 passed (128)
  Start at  13:44:20
  Duration  25.81s (transform 833ms, setup 22.77s, collect 12.55s, tests 79.69s)

 % Coverage report from c8
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 src                         |     100 |      100 |     100 |     100 |                   
  make.ts                    |     100 |      100 |     100 |     100 |                   
 src/config                  |     100 |      100 |     100 |     100 |                   
  constants.ts               |     100 |      100 |     100 |     100 |                   
  define.ts                  |     100 |      100 |     100 |     100 |                   
  load.ts                    |     100 |      100 |     100 |     100 |                   
  loader-es.ts               |     100 |      100 |     100 |     100 |                   
 src/plugins/create-require  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/dts             |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/fully-specified |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/tsconfig-paths  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/utils                   |     100 |      100 |     100 |     100 |                   
  analyze-results.ts         |     100 |      100 |     100 |     100 |                   
  esbuilder.ts               |     100 |      100 |     100 |     100 |                   
  extract-statements.ts      |     100 |      100 |     100 |     100 |                   
  get-compiler-options.ts    |     100 |      100 |     100 |     100 |                   
  loaders.ts                 |     100 |      100 |     100 |     100 |                   
  write.ts                   |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mkbuild                                                                13:47:11
✔ Build succeeded for @flex-development/mkbuild                                                     13:47:18
  dist (total size: 73.6 kB)                                                                        13:47:18
  └─ dist/index.mjs.map (177 B)
  └─ dist/index.mjs (288 B)
  └─ dist/index.d.mts (302 B)
  └─ dist/make.mjs.map (2.76 kB)
  └─ dist/make.mjs (3.52 kB)
  └─ dist/make.d.mts (744 B)
  └─ dist/config/constants.mjs.map (466 B)
  └─ dist/config/constants.mjs (777 B)
  └─ dist/config/constants.d.mts (1.15 kB)
  └─ dist/config/define.mjs.map (152 B)
  └─ dist/config/define.mjs (131 B)
  └─ dist/config/define.d.mts (385 B)
  └─ dist/config/load.mjs.map (529 B)
  └─ dist/config/load.mjs (677 B)
  └─ dist/config/load.d.mts (632 B)
  └─ dist/config/loader-es.mjs.map (637 B)
  └─ dist/config/loader-es.mjs (795 B)
  └─ dist/config/loader-es.d.mts (600 B)
  └─ dist/interfaces/config.mjs.map (69 B)
  └─ dist/interfaces/config.mjs (0 B)
  └─ dist/interfaces/config.d.mts (1.35 kB)
  └─ dist/interfaces/entry.mjs.map (69 B)
  └─ dist/interfaces/entry.mjs (0 B)
  └─ dist/interfaces/entry.d.mts (771 B)
  └─ dist/interfaces/index.mjs.map (69 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (393 B)
  └─ dist/interfaces/options.mjs.map (69 B)
  └─ dist/interfaces/options.mjs (0 B)
  └─ dist/interfaces/options.d.mts (2.19 kB)
  └─ dist/interfaces/result.mjs.map (69 B)
  └─ dist/interfaces/result.mjs (0 B)
  └─ dist/interfaces/result.d.mts (1.23 kB)
  └─ dist/interfaces/source-file.mjs.map (69 B)
  └─ dist/interfaces/source-file.mjs (0 B)
  └─ dist/interfaces/source-file.d.mts (605 B)
  └─ dist/interfaces/statement.mjs.map (69 B)
  └─ dist/interfaces/statement.mjs (0 B)
  └─ dist/interfaces/statement.d.mts (686 B)
  └─ dist/types/esbuild-options.mjs.map (69 B)
  └─ dist/types/esbuild-options.mjs (0 B)
  └─ dist/types/esbuild-options.d.mts (468 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (279 B)
  └─ dist/types/output-extension.mjs.map (69 B)
  └─ dist/types/output-extension.mjs (0 B)
  └─ dist/types/output-extension.d.mts (247 B)
  └─ dist/types/output-metadata.mjs.map (69 B)
  └─ dist/types/output-metadata.mjs (0 B)
  └─ dist/types/output-metadata.d.mts (267 B)
  └─ dist/utils/analyze-results.mjs.map (541 B)
  └─ dist/utils/analyze-results.mjs (575 B)
  └─ dist/utils/analyze-results.d.mts (577 B)
  └─ dist/utils/esbuilder.mjs.map (3.37 kB)
  └─ dist/utils/esbuilder.mjs (4.61 kB)
  └─ dist/utils/esbuilder.d.mts (736 B)
  └─ dist/utils/extract-statements.mjs.map (932 B)
  └─ dist/utils/extract-statements.mjs (1.14 kB)
  └─ dist/utils/extract-statements.d.mts (704 B)
  └─ dist/utils/get-compiler-options.mjs.map (2.9 kB)
  └─ dist/utils/get-compiler-options.mjs (5.39 kB)
  └─ dist/utils/get-compiler-options.d.mts (677 B)
  └─ dist/utils/loaders.mjs.map (671 B)
  └─ dist/utils/loaders.mjs (784 B)
  └─ dist/utils/loaders.d.mts (577 B)
  └─ dist/utils/write.mjs.map (282 B)
  └─ dist/utils/write.mjs (289 B)
  └─ dist/utils/write.d.mts (567 B)
  └─ dist/plugins/create-require/plugin.mjs.map (1.36 kB)
  └─ dist/plugins/create-require/plugin.mjs (1.86 kB)
  └─ dist/plugins/create-require/plugin.d.mts (1.55 kB)
  └─ dist/plugins/dts/plugin.mjs.map (2.49 kB)
  └─ dist/plugins/dts/plugin.mjs (3.93 kB)
  └─ dist/plugins/dts/plugin.d.mts (265 B)
  └─ dist/plugins/fully-specified/plugin.mjs.map (2.13 kB)
  └─ dist/plugins/fully-specified/plugin.mjs (3.32 kB)
  └─ dist/plugins/fully-specified/plugin.d.mts (1.56 kB)
  └─ dist/plugins/tsconfig-paths/options.mjs.map (69 B)
  └─ dist/plugins/tsconfig-paths/options.mjs (0 B)
  └─ dist/plugins/tsconfig-paths/options.d.mts (1.04 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs.map (1.71 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs (2.49 kB)
  └─ dist/plugins/tsconfig-paths/plugin.d.mts (507 B)
  dist (total size: 1.19 MB)                                                                        13:47:18
  └─ dist/cli.mjs.map (676 kB)
  └─ dist/cli.mjs (513 kB)
Σ Total build size: 1.26 MB                                                                         13:47:18
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mkbuild/blob/main/CONTRIBUTING.md#pull-request-titles
