### PR TITLE
release: 1.0.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.0.0-alpha.6](https://github.com/flex-development/mkbuild/compare/1.0.0-alpha.5...1.0.0-alpha.6) (2022-10-02)
+
+
+### :package: Build
+
+* **deps-dev:** bump @flex-development/tutils from 5.0.0 to 5.0.1 ([7cc1c69](https://github.com/flex-development/mkbuild/commit/7cc1c69e11d54fec3125f570d04be83c3f6d472f))
+* **deps:** move @flex-development/tutils to `dependencies` ([eee26a9](https://github.com/flex-development/mkbuild/commit/eee26a95217386f4bd9204b49dec118577b4b94c))
+
+
+### :bug: Fixes
+
+* **plugins:** [`fully-specified`] dot case specifiers support ([b301894](https://github.com/flex-development/mkbuild/commit/b301894aac5f29f9ea36eeb2a21ac737d7732483))
+
 ## [1.0.0-alpha.5](https://github.com/flex-development/mkbuild/compare/1.0.0-alpha.4...1.0.0-alpha.5) (2022-09-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/mkbuild",
   "description": "An esbuild based file-to-file transformer and bundler",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "keywords": [
     "bundle",
     "bundler",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0-alpha.6`
- added `CHANGELOG` entry for `1.0.0-alpha.6`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.23.4
      Coverage enabled with c8

 ✓ src/config/__tests__/define.spec.ts > unit:config/defineBuildConfig > should return build config object
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should do nothing if bundling
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should throw if metafile is not available
 ✓ src/config/__tests__/load.spec.ts > unit:config/loadBuildConfig > should return empty object if config is not found
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should insert require definition
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should insert require definition into minified output
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should skip files without __require shim
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cjs
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .cts file
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if bundling is not enabled
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if not creating esm bundle
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should throw if metafile is not available
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .js file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cts
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in cjs output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in copied output files
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.js
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.json
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mjs file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mjs
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in esm output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should skip files that are not javascript or typescript
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should load build config
 ✓ src/__tests__/make.spec.ts > unit:make > build > should determine current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should clean output directories
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mts
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mts file
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should do nothing if bundling
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should throw if metafile is not available
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.ts
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write all build results
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .ts file
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in cjs output files
 ✓ src/utils/__tests__/analyze-results.spec.ts > unit:utils/analyzeResults > should return pretty printed build results
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should do nothing if bundling
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should throw if metafile is not available
 ✓ src/__tests__/make.spec.ts > unit:make > build > should load package.json from current working directory
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in copied output files
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should enable bundling
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support asset names
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases esm output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should skip files that are not javascript or typescript
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support code splitting
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should use create-require plugin if esm bundle for node
 ✓ src/utils/__tests__/esbuilder.spec.ts > unit:utils/esbuilder > should return build result array
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build start info
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > should return empty array if code is empty string
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return declaration export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return default export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return named export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return star export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > export > should return type export statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > dynamic > should return dynamic import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return default import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > import > static > should return named import statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require statement array
 ✓ src/utils/__tests__/extract-statements.spec.ts > unit:utils/extractStatements > require > should return require.resolve statement array
 ✓ src/__tests__/make.spec.ts > unit:make > build > should build source files
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm transpilation
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs transpilation
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should create subdirectories in output directory
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should write build result
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should return written build result
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should write build result to file system
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object is tsconfig is not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object if user options are not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return user options
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "error" to ImportsNotUsedAsValues.Error
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "preserve" to ImportsNotUsedAsValues.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "remove" to ImportsNotUsedAsValues.Remove
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "preserve" to JsxEmit.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react" to JsxEmit.React
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsx" to JsxEmit.ReactJSX
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsxdev" to JsxEmit.ReactJSXDev
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-native" to JsxEmit.ReactNative
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > lib > should convert libs into typescript library file names
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "amd" to ModuleKind.AMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "commonjs" to ModuleKind.CommonJS
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2015" to ModuleKind.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2020" to ModuleKind.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2022" to ModuleKind.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "esnext" to ModuleKind.ESNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "node16" to ModuleKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "nodenext" to ModuleKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "none" to ModuleKind.None
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "system" to ModuleKind.System
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "umd" to ModuleKind.UMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "auto" to ModuleDetectionKind.Auto
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "force" to ModuleDetectionKind.Force
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "legacy" to ModuleDetectionKind.Legacy
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "classic" to ModuleResolutionKind.Classic
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node" to ModuleResolutionKind.NodeJs
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node16" to ModuleResolutionKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "nodenext" to ModuleResolutionKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "crlf" to NewLineKind.CarriageReturnLineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "lf" to NewLineKind.LineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es3" to ScriptTarget.ES3
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es5" to ScriptTarget.ES5
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2015" to ScriptTarget.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2016" to ScriptTarget.ES2016
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2017" to ScriptTarget.ES2017
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2018" to ScriptTarget.ES2018
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2019" to ScriptTarget.ES2019
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2020" to ScriptTarget.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2021" to ScriptTarget.ES2021
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2022" to ScriptTarget.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "esnext" to ScriptTarget.ESNext
 ✓ src/__tests__/make.spec.ts > unit:make > build > should write build results
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build done info
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use create-require if requested
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build analysis
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output for copied file
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print total build size
 ✓ src/__tests__/make.spec.ts > unit:make > build > should return build results
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if package.json is not found
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error building source file
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write dts build results only
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use dts if declarations are enabled
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use fully-specified if specifers require extensions
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error writing build result
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use tsconfig-paths if tsconfig is detected
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > transpiling > should disable bundling
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.ts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should skip files that are not javascript or typescript

Test Files  22 passed (22)
     Tests  129 passed (129)
  Start at  00:51:41
  Duration  24.80s (transform 740ms, setup 27.32s, collect 12.90s, tests 70.54s)

 % Coverage report from c8
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 src                         |     100 |      100 |     100 |     100 |                   
  make.ts                    |     100 |      100 |     100 |     100 |                   
 src/config                  |     100 |      100 |     100 |     100 |                   
  constants.ts               |     100 |      100 |     100 |     100 |                   
  define.ts                  |     100 |      100 |     100 |     100 |                   
  load.ts                    |     100 |      100 |     100 |     100 |                   
  loader-es.ts               |     100 |      100 |     100 |     100 |                   
 src/plugins/create-require  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/dts             |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/fully-specified |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/tsconfig-paths  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/utils                   |     100 |      100 |     100 |     100 |                   
  analyze-results.ts         |     100 |      100 |     100 |     100 |                   
  esbuilder.ts               |     100 |      100 |     100 |     100 |                   
  extract-statements.ts      |     100 |      100 |     100 |     100 |                   
  get-compiler-options.ts    |     100 |      100 |     100 |     100 |                   
  loaders.ts                 |     100 |      100 |     100 |     100 |                   
  write.ts                   |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mkbuild                                                                00:57:49
✔ Build succeeded for @flex-development/mkbuild                                                     00:57:56
  dist (total size: 73.8 kB)                                                                        00:57:56
  └─ dist/index.mjs.map (177 B)
  └─ dist/index.mjs (288 B)
  └─ dist/index.d.mts (302 B)
  └─ dist/make.mjs.map (2.79 kB)
  └─ dist/make.mjs (3.58 kB)
  └─ dist/make.d.mts (759 B)
  └─ dist/config/constants.mjs.map (466 B)
  └─ dist/config/constants.mjs (777 B)
  └─ dist/config/constants.d.mts (1.15 kB)
  └─ dist/config/define.mjs.map (152 B)
  └─ dist/config/define.mjs (131 B)
  └─ dist/config/define.d.mts (385 B)
  └─ dist/config/load.mjs.map (529 B)
  └─ dist/config/load.mjs (677 B)
  └─ dist/config/load.d.mts (632 B)
  └─ dist/config/loader-es.mjs.map (637 B)
  └─ dist/config/loader-es.mjs (795 B)
  └─ dist/config/loader-es.d.mts (600 B)
  └─ dist/interfaces/config.mjs.map (69 B)
  └─ dist/interfaces/config.mjs (0 B)
  └─ dist/interfaces/config.d.mts (1.3 kB)
  └─ dist/interfaces/entry.mjs.map (69 B)
  └─ dist/interfaces/entry.mjs (0 B)
  └─ dist/interfaces/entry.d.mts (771 B)
  └─ dist/interfaces/index.mjs.map (69 B)
  └─ dist/interfaces/index.mjs (0 B)
  └─ dist/interfaces/index.d.mts (393 B)
  └─ dist/interfaces/options.mjs.map (69 B)
  └─ dist/interfaces/options.mjs (0 B)
  └─ dist/interfaces/options.d.mts (2.32 kB)
  └─ dist/interfaces/result.mjs.map (69 B)
  └─ dist/interfaces/result.mjs (0 B)
  └─ dist/interfaces/result.d.mts (1.23 kB)
  └─ dist/interfaces/source-file.mjs.map (69 B)
  └─ dist/interfaces/source-file.mjs (0 B)
  └─ dist/interfaces/source-file.d.mts (605 B)
  └─ dist/interfaces/statement.mjs.map (69 B)
  └─ dist/interfaces/statement.mjs (0 B)
  └─ dist/interfaces/statement.d.mts (686 B)
  └─ dist/types/esbuild-options.mjs.map (69 B)
  └─ dist/types/esbuild-options.mjs (0 B)
  └─ dist/types/esbuild-options.d.mts (435 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (0 B)
  └─ dist/types/index.d.mts (279 B)
  └─ dist/types/output-extension.mjs.map (69 B)
  └─ dist/types/output-extension.mjs (0 B)
  └─ dist/types/output-extension.d.mts (247 B)
  └─ dist/types/output-metadata.mjs.map (69 B)
  └─ dist/types/output-metadata.mjs (0 B)
  └─ dist/types/output-metadata.d.mts (267 B)
  └─ dist/utils/analyze-results.mjs.map (541 B)
  └─ dist/utils/analyze-results.mjs (575 B)
  └─ dist/utils/analyze-results.d.mts (577 B)
  └─ dist/utils/esbuilder.mjs.map (3.37 kB)
  └─ dist/utils/esbuilder.mjs (4.61 kB)
  └─ dist/utils/esbuilder.d.mts (736 B)
  └─ dist/utils/extract-statements.mjs.map (932 B)
  └─ dist/utils/extract-statements.mjs (1.14 kB)
  └─ dist/utils/extract-statements.d.mts (704 B)
  └─ dist/utils/get-compiler-options.mjs.map (2.9 kB)
  └─ dist/utils/get-compiler-options.mjs (5.39 kB)
  └─ dist/utils/get-compiler-options.d.mts (677 B)
  └─ dist/utils/loaders.mjs.map (671 B)
  └─ dist/utils/loaders.mjs (784 B)
  └─ dist/utils/loaders.d.mts (577 B)
  └─ dist/utils/write.mjs.map (282 B)
  └─ dist/utils/write.mjs (289 B)
  └─ dist/utils/write.d.mts (567 B)
  └─ dist/plugins/create-require/plugin.mjs.map (1.41 kB)
  └─ dist/plugins/create-require/plugin.mjs (1.94 kB)
  └─ dist/plugins/create-require/plugin.d.mts (1.55 kB)
  └─ dist/plugins/dts/plugin.mjs.map (2.49 kB)
  └─ dist/plugins/dts/plugin.mjs (3.93 kB)
  └─ dist/plugins/dts/plugin.d.mts (265 B)
  └─ dist/plugins/fully-specified/plugin.mjs.map (2.11 kB)
  └─ dist/plugins/fully-specified/plugin.mjs (3.3 kB)
  └─ dist/plugins/fully-specified/plugin.d.mts (1.56 kB)
  └─ dist/plugins/tsconfig-paths/options.mjs.map (69 B)
  └─ dist/plugins/tsconfig-paths/options.mjs (0 B)
  └─ dist/plugins/tsconfig-paths/options.d.mts (1.04 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs.map (1.71 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs (2.49 kB)
  └─ dist/plugins/tsconfig-paths/plugin.d.mts (507 B)
  dist (total size: 1.18 MB)                                                                        00:57:56
  └─ dist/cli.mjs.map (673 kB)
  └─ dist/cli.mjs (512 kB)
Σ Total build size: 1.26 MB                                                                         00:57:56
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mkbuild/blob/main/CONTRIBUTING.md#pull-request-titles
