### PR TITLE
release: 1.0.0-alpha.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.0.0-alpha.9](https://github.com/flex-development/mkbuild/compare/1.0.0-alpha.8...1.0.0-alpha.9) (2022-11-06)
+
+
+### :package: Build
+
+* **deps:** use @flex-development/mlly@1.0.0-alpha.2 ([94ddedb](https://github.com/flex-development/mkbuild/commit/94ddedba5c8d75510fc4829695d5b7c113b865f6))
+
+
+### :robot: Continuous Integration
+
+* **deps:** bump dependabot/fetch-metadata from 1.3.3 to 1.3.5 ([#31](https://github.com/flex-development/mkbuild/issues/31)) ([d6aef35](https://github.com/flex-development/mkbuild/commit/d6aef350979a98a016ce329b186c2e53705ce8fd))
+
 ## [1.0.0-alpha.8](https://github.com/flex-development/mkbuild/compare/1.0.0-alpha.7...1.0.0-alpha.8) (2022-10-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/mkbuild",
   "description": "An esbuild based file-to-file transformer and bundler",
-  "version": "1.0.0-alpha.8",
+  "version": "1.0.0-alpha.9",
   "keywords": [
     "bundle",
     "bundler",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0-alpha.9`
- added `CHANGELOG` entry for `1.0.0-alpha.9`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.24.3
      Coverage enabled with c8

 ✓ src/config/__tests__/define.spec.ts > unit:config/defineBuildConfig > should return build config object
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should insert require definition
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if bundling is not enabled
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should do nothing if not creating esm bundle
 ✓ src/plugins/create-require/__tests__/plugin.spec.ts > unit:plugins/create-require > should throw if metafile is not available
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should do nothing if bundling
 ✓ src/plugins/dts/__tests__/plugin.spec.ts > unit:plugins/dts > should throw if metafile is not available
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should insert require definition into minified output
 ✓ src/plugins/create-require/__tests__/plugin.integration.spec.ts > integration:plugins/create-require > esbuild > should skip files without __require shim
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in cjs output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in copied output files
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .cts file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .js file
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mjs file
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should fill specifiers in esm output files
 ✓ src/plugins/fully-specified/__tests__/plugin.integration.spec.ts > integration:plugins/fully-specified > esbuild > should skip files that are not javascript or typescript
 ✓ src/config/__tests__/load.spec.ts > unit:config/loadBuildConfig > should return empty object if config is not found
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cjs
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.cts
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.js
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.json
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mjs
 ✓ src/__tests__/make.spec.ts > unit:make > build > should determine current working directory
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should load build config
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should clean output directories
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write all build results
 ✓ src/__tests__/make.spec.ts > unit:make > build > should load package.json from current working directory
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build start info
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .mts file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.mts
 ✓ src/__tests__/make.spec.ts > unit:make > build > should build source files
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should do nothing if bundling
 ✓ src/plugins/fully-specified/__tests__/plugin.spec.ts > unit:plugins/fully-specified > should throw if metafile is not available
 ✓ src/config/__tests__/loader-es.spec.ts > unit:config/esLoader > should return config from .ts file
 ✓ src/config/__tests__/load.integration.spec.ts > integration:config/loadBuildConfig > cosmiconfig > should load config from build.config.ts
 ✓ src/utils/__tests__/analyze-results.spec.ts > unit:utils/analyzeResults > should return pretty printed build results
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in cjs output files
 ✓ src/__tests__/make.spec.ts > unit:make > build > should write build results
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should do nothing if bundling
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.spec.ts > unit:plugins/tsconfig-paths > should throw if metafile is not available
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases in copied output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should resolve path aliases esm output files
 ✓ src/plugins/tsconfig-paths/__tests__/plugin.integration.spec.ts > integration:plugins/tsconfig-paths > esbuild > should skip files that are not javascript or typescript
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build done info
 ✓ src/utils/__tests__/esbuilder.spec.ts > unit:utils/esbuilder > should return build result array
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should enable bundling
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print build analysis
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support asset names
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should support code splitting
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > bundling > should use create-require plugin if esm bundle for node
 ✓ src/__tests__/make.spec.ts > unit:make > build > should print total build size
 ✓ src/__tests__/make.spec.ts > unit:make > build > should return build results
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm transpilation
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for esm bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs bundle
 ✓ src/utils/__tests__/loaders.spec.ts > unit:utils/loaders > should return esbuild loader config for cjs transpilation
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should create subdirectories in output directory
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should write build result
 ✓ src/utils/__tests__/write.spec.ts > unit:utils/write > should return written build result
 ✓ src/utils/__tests__/write.functional.spec.ts > functional:utils/write > should write build result to file system
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object is tsconfig is not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return empty object if user options are not found
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > should return user options
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "error" to ImportsNotUsedAsValues.Error
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "preserve" to ImportsNotUsedAsValues.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > importsNotUsedAsValues > should convert "remove" to ImportsNotUsedAsValues.Remove
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "preserve" to JsxEmit.Preserve
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react" to JsxEmit.React
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsx" to JsxEmit.ReactJSX
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-jsxdev" to JsxEmit.ReactJSXDev
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > jsx > should convert "react-native" to JsxEmit.ReactNative
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > lib > should convert libs into typescript library file names
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "amd" to ModuleKind.AMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "commonjs" to ModuleKind.CommonJS
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2015" to ModuleKind.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2020" to ModuleKind.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "es2022" to ModuleKind.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "esnext" to ModuleKind.ESNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "node16" to ModuleKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "nodenext" to ModuleKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "none" to ModuleKind.None
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "system" to ModuleKind.System
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > module > should convert "umd" to ModuleKind.UMD
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "auto" to ModuleDetectionKind.Auto
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "force" to ModuleDetectionKind.Force
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleDetection > should convert "legacy" to ModuleDetectionKind.Legacy
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "classic" to ModuleResolutionKind.Classic
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node" to ModuleResolutionKind.NodeJs
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "node16" to ModuleResolutionKind.Node16
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > moduleResolution > should convert "nodenext" to ModuleResolutionKind.NodeNext
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "crlf" to NewLineKind.CarriageReturnLineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > newLine > should convert "lf" to NewLineKind.LineFeed
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es3" to ScriptTarget.ES3
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es5" to ScriptTarget.ES5
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2015" to ScriptTarget.ES2015
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2016" to ScriptTarget.ES2016
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2017" to ScriptTarget.ES2017
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2018" to ScriptTarget.ES2018
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2019" to ScriptTarget.ES2019
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2020" to ScriptTarget.ES2020
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2021" to ScriptTarget.ES2021
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "es2022" to ScriptTarget.ES2022
 ✓ src/utils/__tests__/get-compiler-options.spec.ts > unit:utils/getCompilerOptions > normalization > target > should convert "esnext" to ScriptTarget.ESNext
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if package.json is not found
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error building source file
 ✓ src/__tests__/make.spec.ts > unit:make > error handling > should exit early if error writing build result
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use create-require if requested
 ✓ src/__tests__/make.functional.spec.ts > functional:make > should write dts build results only
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.cts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use dts if declarations are enabled
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use fully-specified if specifers require extensions
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.mts output for copied file
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should add .d.ts output
 ✓ src/plugins/dts/__tests__/plugin.integration.spec.ts > integration:plugins/dts > esbuild > should skip files that are not javascript or typescript
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > plugins > should use tsconfig-paths if tsconfig is detected
 ✓ src/utils/__tests__/esbuilder.integration.spec.ts > integration:utils/esbuilder > esbuild > transpiling > should disable bundling

Test Files  21 passed (21)
     Tests  118 passed (118)
  Start at  05:44:50
  Duration  29.10s (transform 686ms, setup 26.97s, collect 23.38s, tests 77.14s)

 % Coverage report from c8
-----------------------------|---------|----------|---------|---------|-------------------
File                         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------------------|---------|----------|---------|---------|-------------------
All files                    |     100 |      100 |     100 |     100 |                   
 src                         |     100 |      100 |     100 |     100 |                   
  make.ts                    |     100 |      100 |     100 |     100 |                   
 src/config                  |     100 |      100 |     100 |     100 |                   
  constants.ts               |     100 |      100 |     100 |     100 |                   
  define.ts                  |     100 |      100 |     100 |     100 |                   
  load.ts                    |     100 |      100 |     100 |     100 |                   
  loader-es.ts               |     100 |      100 |     100 |     100 |                   
 src/plugins/create-require  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/dts             |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/fully-specified |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/plugins/tsconfig-paths  |     100 |      100 |     100 |     100 |                   
  plugin.ts                  |     100 |      100 |     100 |     100 |                   
 src/utils                   |     100 |      100 |     100 |     100 |                   
  analyze-results.ts         |     100 |      100 |     100 |     100 |                   
  esbuilder.ts               |     100 |      100 |     100 |     100 |                   
  get-compiler-options.ts    |     100 |      100 |     100 |     100 |                   
  loaders.ts                 |     100 |      100 |     100 |     100 |                   
  write.ts                   |     100 |      100 |     100 |     100 |                   
-----------------------------|---------|----------|---------|---------|-------------------
```

### `yarn build`

```zsh
ℹ Building @flex-development/mkbuild                                                                05:45:34
✔ Build succeeded for @flex-development/mkbuild                                                     05:45:41
  dist (total size: 72.5 kB)                                                                        05:45:41
  └─ dist/index.mjs.map (205 B)
  └─ dist/index.mjs (409 B)
  └─ dist/index.d.mts (317 B)
  └─ dist/make.mjs.map (2.79 kB)
  └─ dist/make.mjs (3.61 kB)
  └─ dist/make.d.mts (759 B)
  └─ dist/config/constants.mjs.map (235 B)
  └─ dist/config/constants.mjs (416 B)
  └─ dist/config/constants.d.mts (630 B)
  └─ dist/config/define.mjs.map (152 B)
  └─ dist/config/define.mjs (167 B)
  └─ dist/config/define.d.mts (385 B)
  └─ dist/config/load.mjs.map (529 B)
  └─ dist/config/load.mjs (711 B)
  └─ dist/config/load.d.mts (632 B)
  └─ dist/config/loader-es.mjs.map (654 B)
  └─ dist/config/loader-es.mjs (853 B)
  └─ dist/config/loader-es.d.mts (600 B)
  └─ dist/interfaces/compiler-options-json.mjs.map (69 B)
  └─ dist/interfaces/compiler-options-json.mjs (51 B)
  └─ dist/interfaces/compiler-options-json.d.mts (6.05 kB)
  └─ dist/interfaces/config.mjs.map (69 B)
  └─ dist/interfaces/config.mjs (36 B)
  └─ dist/interfaces/config.d.mts (1.3 kB)
  └─ dist/interfaces/entry.mjs.map (69 B)
  └─ dist/interfaces/entry.mjs (35 B)
  └─ dist/interfaces/entry.d.mts (771 B)
  └─ dist/interfaces/index.mjs.map (69 B)
  └─ dist/interfaces/index.mjs (35 B)
  └─ dist/interfaces/index.d.mts (336 B)
  └─ dist/interfaces/options.mjs.map (69 B)
  └─ dist/interfaces/options.mjs (37 B)
  └─ dist/interfaces/options.d.mts (2.32 kB)
  └─ dist/interfaces/result.mjs.map (69 B)
  └─ dist/interfaces/result.mjs (36 B)
  └─ dist/interfaces/result.d.mts (1.23 kB)
  └─ dist/interfaces/source-file.mjs.map (69 B)
  └─ dist/interfaces/source-file.mjs (41 B)
  └─ dist/interfaces/source-file.d.mts (605 B)
  └─ dist/types/esbuild-options.mjs.map (69 B)
  └─ dist/types/esbuild-options.mjs (45 B)
  └─ dist/types/esbuild-options.d.mts (435 B)
  └─ dist/types/index.mjs.map (69 B)
  └─ dist/types/index.mjs (35 B)
  └─ dist/types/index.d.mts (279 B)
  └─ dist/types/output-extension.mjs.map (69 B)
  └─ dist/types/output-extension.mjs (46 B)
  └─ dist/types/output-extension.d.mts (247 B)
  └─ dist/types/output-metadata.mjs.map (69 B)
  └─ dist/types/output-metadata.mjs (45 B)
  └─ dist/types/output-metadata.d.mts (267 B)
  └─ dist/utils/analyze-results.mjs.map (541 B)
  └─ dist/utils/analyze-results.mjs (620 B)
  └─ dist/utils/analyze-results.d.mts (577 B)
  └─ dist/utils/esbuilder.mjs.map (3.32 kB)
  └─ dist/utils/esbuilder.mjs (4.6 kB)
  └─ dist/utils/esbuilder.d.mts (736 B)
  └─ dist/utils/get-compiler-options.mjs.map (2.9 kB)
  └─ dist/utils/get-compiler-options.mjs (5.42 kB)
  └─ dist/utils/get-compiler-options.d.mts (862 B)
  └─ dist/utils/loaders.mjs.map (671 B)
  └─ dist/utils/loaders.mjs (821 B)
  └─ dist/utils/loaders.d.mts (577 B)
  └─ dist/utils/write.mjs.map (282 B)
  └─ dist/utils/write.mjs (324 B)
  └─ dist/utils/write.d.mts (567 B)
  └─ dist/plugins/create-require/plugin.mjs.map (1.41 kB)
  └─ dist/plugins/create-require/plugin.mjs (1.97 kB)
  └─ dist/plugins/create-require/plugin.d.mts (1.55 kB)
  └─ dist/plugins/dts/plugin.mjs.map (2.48 kB)
  └─ dist/plugins/dts/plugin.mjs (3.94 kB)
  └─ dist/plugins/dts/plugin.d.mts (265 B)
  └─ dist/plugins/fully-specified/plugin.mjs.map (1.34 kB)
  └─ dist/plugins/fully-specified/plugin.mjs (1.92 kB)
  └─ dist/plugins/fully-specified/plugin.d.mts (1.56 kB)
  └─ dist/plugins/tsconfig-paths/options.mjs.map (69 B)
  └─ dist/plugins/tsconfig-paths/options.mjs (37 B)
  └─ dist/plugins/tsconfig-paths/options.d.mts (530 B)
  └─ dist/plugins/tsconfig-paths/plugin.mjs.map (1.25 kB)
  └─ dist/plugins/tsconfig-paths/plugin.mjs (1.79 kB)
  └─ dist/plugins/tsconfig-paths/plugin.d.mts (507 B)
  dist (total size: 1.11 MB)                                                                        05:45:41
  └─ dist/cli.mjs.map (640 kB)
  └─ dist/cli.mjs (470 kB)
Σ Total build size: 1.18 MB                                                                         05:45:41
```

## Additional context

<!-- Add any other information (docs, files, issue references, etc) about the pull request here. -->

N/A

## Linked issues

<!-- closes #[issue number], fixes #[issue number] -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/mkbuild/blob/main/CONTRIBUTING.md#pull-request-titles
